### PR TITLE
Revert "Clickable Date with non grayed out input, custom suggetionsCallback for dropdown_writable_input"

### DIFF
--- a/lib/src/widgets/inputs/custom_input_otp.dart
+++ b/lib/src/widgets/inputs/custom_input_otp.dart
@@ -141,13 +141,13 @@ class _CustomInputOtpState extends State<CustomInputOtp> {
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
         cursorColor: Colors.transparent,
-        buildCounter:
-            (
-              context, {
-              maxLength,
-              required isFocused,
-              required currentLength,
-            }) => null,
+        buildCounter: (
+          context, {
+          maxLength,
+          required isFocused,
+          required currentLength,
+        }) =>
+            null,
         style: widget.controller.text == "*"
             ? context.mobileTitleText.copyWith(color: Colors.transparent)
             : context.mobileTitleText,

--- a/lib/src/widgets/inputs/custom_input_otp_mobile.dart
+++ b/lib/src/widgets/inputs/custom_input_otp_mobile.dart
@@ -41,10 +41,10 @@ class _CustomInputOtpMobileState extends State<CustomInputOtpMobile> {
       widget.controller.text = "*";
       widget.controller.selection = TextSelection.collapsed(offset: 1);
     }
-
+    
     // Escuchar cambios en el controlador
     widget.controller.addListener(_onControllerChanged);
-
+    
     // Escuchar cuando se obtiene el foco
     widget.focusNode?.addListener(_onFocusChanged);
   }
@@ -71,13 +71,13 @@ class _CustomInputOtpMobileState extends State<CustomInputOtpMobile> {
     if (widget.controller.text.isEmpty && _isInitialized) {
       widget.controller.text = "*";
       widget.controller.selection = TextSelection.collapsed(offset: 1);
-
+      
       // Navegar al input anterior
       int currentIndex = widget.allControllers.indexOf(widget.controller);
       if (currentIndex > 0) {
         widget.allFocusNodes[currentIndex - 1].requestFocus();
       }
-
+      
       setState(() {}); // Actualizar UI
     } else {
       // Actualizar UI para cualquier cambio en el controlador
@@ -117,7 +117,7 @@ class _CustomInputOtpMobileState extends State<CustomInputOtpMobile> {
         widget.allFocusNodes[currentIndex - 1].requestFocus();
       }
     }
-
+    
     // Actualizar UI después de cualquier cambio
     setState(() {});
   }
@@ -142,21 +142,16 @@ class _CustomInputOtpMobileState extends State<CustomInputOtpMobile> {
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
         cursorColor: Colors.transparent, // Cursor transparente
-        buildCounter:
-            (
-              context, {
-              maxLength,
-              required isFocused,
-              required currentLength,
-            }) => null,
-        style: widget.controller.text == "*"
-            ? context.mobileTitleText.copyWith(
-                color: Colors.transparent,
-                fontSize: 34, // Tamaño de fuente reducido
-              )
-            : context.mobileTitleText.copyWith(
-                fontSize: 34, // Tamaño de fuente reducido
-              ),
+        buildCounter: (
+          context, {
+          maxLength,
+          required isFocused,
+          required currentLength,
+        }) =>
+            null,
+        style: widget.controller.text == "*" 
+            ? context.mobileTitleText.copyWith(color: Colors.transparent)
+            : context.mobileTitleText,
         textAlign: TextAlign.center,
         decoration: InputDecoration(
           filled: true,

--- a/lib/src/widgets/inputs/dynamic_dropdown_writable_input.dart
+++ b/lib/src/widgets/inputs/dynamic_dropdown_writable_input.dart
@@ -21,7 +21,6 @@ class DynamicDropdownWritableInput<T> extends StatefulWidget {
     required this.getStringValue,
     required this.onSuggestionCallback,
     this.type = DropdownWritableInputType.SINGLE,
-    this.getItemWidget,
   }) : this.inputColor = inputColor ?? PrimaryInputColorKit.BLUE;
 
   final String label;
@@ -40,7 +39,6 @@ class DynamicDropdownWritableInput<T> extends StatefulWidget {
   final TextEditingController dropdownSearchFieldController;
   final String Function(T) getStringValue;
   final Function(String) onSuggestionCallback;
-  final Widget Function(dynamic)? getItemWidget;
 
   /// Converts an item of type T into a String using the provided getStringValue function.
   String convertToString<T>(item) {
@@ -74,10 +72,10 @@ class _DynamicDropdownWritableInputState<T>
           textFieldConfiguration: TextFieldConfiguration(
             enabled: widget.enabled,
             style: AppearanceKitTextTheme.build().input.copyWith(
-              color: _generateColor(),
-              fontSize: widget.fontSize,
-              fontWeight: FontWeight.w400,
-            ),
+                  color: _generateColor(),
+                  fontSize: widget.fontSize,
+                  fontWeight: FontWeight.w400,
+                ),
             cursorColor: _generateColor(),
             decoration: InputDecoration(
               labelText: widget.label,
@@ -96,25 +94,20 @@ class _DynamicDropdownWritableInputState<T>
                 borderSide: BorderSide(color: _generateColor()),
               ),
               hintStyle: AppearanceKitTextTheme.build().input.copyWith(
-                color: _generateColor(),
-                fontSize: widget.fontSize,
-              ),
+                    color: _generateColor(),
+                    fontSize: widget.fontSize,
+                  ),
               labelStyle: AppearanceKitTextTheme.build().input.copyWith(
-                color: _generateColor(),
-                fontSize: widget.fontSize,
-              ),
+                    color: _generateColor(),
+                    fontSize: widget.fontSize,
+                  ),
             ),
             controller: widget.dropdownSearchFieldController,
           ),
           suggestionsCallback: (pattern) =>
               widget.onSuggestionCallback(pattern),
-          itemBuilder: (context, dynamic suggestion) {
-            if (widget.getItemWidget != null) {
-              return ListTile(title: widget.getItemWidget!(suggestion));
-            }
-            return ListTile(
-              title: Text(widget.convertToString(suggestion as T)),
-            );
+          itemBuilder: (context, T suggestion) {
+            return ListTile(title: Text(widget.convertToString(suggestion)));
           },
           itemSeparatorBuilder: (context, index) => Divider(),
           transitionBuilder: (context, suggestionsBox, controller) {
@@ -134,14 +127,13 @@ class _DynamicDropdownWritableInputState<T>
               }
               widget.onSuggestionSelected(suggestion);
             } else {
-              widget.dropdownSearchFieldController.text = widget
-                  .convertToString(suggestion);
+              widget.dropdownSearchFieldController.text =
+                  widget.convertToString(suggestion);
               widget.onSuggestionSelected(suggestion);
             }
           },
           suggestionsBoxController: suggestionBoxController,
-          validator:
-              widget.validator ??
+          validator: widget.validator ??
               (value) {
                 if (value!.isEmpty &&
                     widget.type == DropdownWritableInputType.SINGLE) {
@@ -156,26 +148,28 @@ class _DynamicDropdownWritableInputState<T>
         if (widget.selectedValues.isNotEmpty)
           Wrap(
             spacing: 5.0,
-            children: List<Widget>.generate(widget.selectedValues.length, (
-              int index,
-            ) {
-              return Padding(
-                padding: const EdgeInsets.all(2.0),
-                child: Chip(
-                  label: Text(
-                    widget.selectedValues[index],
-                    style: TextStyle(fontSize: widget.fontSize),
+            children: List<Widget>.generate(
+              widget.selectedValues.length,
+              (int index) {
+                return Padding(
+                  padding: const EdgeInsets.all(2.0),
+                  child: Chip(
+                    label: Text(widget.selectedValues[index],
+                        style: TextStyle(
+                          fontSize: widget.fontSize,
+                        )),
+                    onDeleted: () {
+                      widget.selectedValues
+                          .remove(widget.selectedValues[index]);
+                      setState(() {});
+                      if (widget.onSelectedValuesChanged != null) {
+                        widget.onSelectedValuesChanged!(widget.selectedValues);
+                      }
+                    },
                   ),
-                  onDeleted: () {
-                    widget.selectedValues.remove(widget.selectedValues[index]);
-                    setState(() {});
-                    if (widget.onSelectedValuesChanged != null) {
-                      widget.onSelectedValuesChanged!(widget.selectedValues);
-                    }
-                  },
-                ),
-              );
-            }).toList(),
+                );
+              },
+            ).toList(),
           ),
       ],
     );

--- a/lib/src/widgets/inputs/input_index.dart
+++ b/lib/src/widgets/inputs/input_index.dart
@@ -143,7 +143,6 @@ class Inputs {
     EdgeInsets? contentPadding,
     required String Function(T) getStringValue,
     required Function(String) onSuggestionCallback,
-    Widget Function(dynamic)? getItemWidget,
   }) =>
       DynamicDropdownWritableInput<T>(
         getStringValue: getStringValue,
@@ -162,7 +161,6 @@ class Inputs {
         onSuggestionCallback: onSuggestionCallback,
         onSelectedValuesChanged: onSelectedValuesChanged,
         dropdownSearchFieldController: dropdownSearchFieldController,
-        getItemWidget: getItemWidget,
       );
 
   Widget otpInput({

--- a/lib/src/widgets/list/grid_view_generator.dart
+++ b/lib/src/widgets/list/grid_view_generator.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:forms360_uikit/forms360_uikit.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
-class GridViewGenerator<T> extends StatefulWidget {
+class GridViewGenerator<T> extends StatelessWidget {
   final List<T> list;
   final String? label;
   final IconData? icon;
@@ -23,35 +23,13 @@ class GridViewGenerator<T> extends StatefulWidget {
   });
 
   @override
-  State<GridViewGenerator<T>> createState() => _GridViewGeneratorState<T>();
-}
-
-class _GridViewGeneratorState<T> extends State<GridViewGenerator<T>> {
-  late final ScrollController _scrollController;
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return widget.list.isNotEmpty
+    return list.isNotEmpty
         ? ScrollbarTheme(
             data: ScrollbarThemeData(
-              thumbColor: MaterialStateProperty.all(
-                context.primaryColor.withOpacity(0.5),
-              ),
+              thumbColor: MaterialStateProperty.all(context.primaryColor.withOpacity(0.5)),
             ),
             child: Scrollbar(
-              controller: _scrollController,
               thickness: 6.0,
               interactive: true,
               thumbVisibility: true,
@@ -59,13 +37,11 @@ class _GridViewGeneratorState<T> extends State<GridViewGenerator<T>> {
               radius: Radius.circular(10),
               scrollbarOrientation: ScrollbarOrientation.right,
               child: MasonryGridView.count(
-                controller: _scrollController,
-                itemCount: widget.list.length,
-                crossAxisCount: widget.crossAxisCount ?? 3,
-                mainAxisSpacing: widget.mainAxisSpacing ?? 16,
-                crossAxisSpacing: widget.crossAxisSpacing ?? 30,
-                itemBuilder: (_, int index) =>
-                    widget.itemBuilder(widget.list[index], index),
+                itemCount: list.length,
+                crossAxisCount: crossAxisCount ?? 3,
+                mainAxisSpacing: mainAxisSpacing ?? 16,
+                crossAxisSpacing: crossAxisSpacing ?? 30,
+                itemBuilder: (_, int index) => itemBuilder(list[index], index),
               ),
             ),
           )
@@ -76,17 +52,17 @@ class _GridViewGeneratorState<T> extends State<GridViewGenerator<T>> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  widget.icon ?? Icons.inbox,
+                  icon ?? Icons.inbox,
                   size: 60,
                   color: context.primaryColor,
                 ),
                 SizedBox(height: 10),
                 Text(
-                  widget.label ?? "No matching records found",
+                  label ?? "No matching records found",
                   style: FormsKit.theme.text.primary.copyWith(
                     color: context.primaryColor,
                   ),
-                ),
+                )
               ],
             ),
           );

--- a/lib/src/widgets/list/list_generator.dart
+++ b/lib/src/widgets/list/list_generator.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forms360_uikit/forms360_uikit.dart';
 
-class ListGenerator<T> extends StatefulWidget {
+class ListGenerator<T> extends StatelessWidget {
   final List<T> list;
   final String? label;
   final IconData? icon;
@@ -16,35 +16,13 @@ class ListGenerator<T> extends StatefulWidget {
   });
 
   @override
-  State<ListGenerator<T>> createState() => _ListGeneratorState<T>();
-}
-
-class _ListGeneratorState<T> extends State<ListGenerator<T>> {
-  late final ScrollController _scrollController;
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return widget.list.isNotEmpty
+    return list.isNotEmpty
         ? ScrollbarTheme(
             data: ScrollbarThemeData(
-              thumbColor: MaterialStateProperty.all(
-                context.primaryColor.withOpacity(0.5),
-              ),
+              thumbColor: MaterialStateProperty.all(context.primaryColor.withOpacity(0.5)),
             ),
             child: Scrollbar(
-              controller: _scrollController,
               thickness: 6.0,
               interactive: true,
               thumbVisibility: true,
@@ -52,10 +30,8 @@ class _ListGeneratorState<T> extends State<ListGenerator<T>> {
               radius: Radius.circular(10),
               scrollbarOrientation: ScrollbarOrientation.right,
               child: ListView.builder(
-                controller: _scrollController,
-                itemCount: widget.list.length,
-                itemBuilder: (_, int index) =>
-                    widget.itemBuilder(widget.list[index], index),
+                itemCount: list.length,
+                itemBuilder: (_, int index) => itemBuilder(list[index], index),
               ),
             ),
           )
@@ -66,17 +42,17 @@ class _ListGeneratorState<T> extends State<ListGenerator<T>> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  widget.icon ?? Icons.inbox,
+                  icon ?? Icons.inbox,
                   size: 60,
                   color: context.primaryColor,
                 ),
                 SizedBox(height: 10),
                 Text(
-                  widget.label ?? "No matching records found",
+                  label ?? "No matching records found",
                   style: FormsKit.theme.text.primary.copyWith(
                     color: context.primaryColor,
                   ),
-                ),
+                )
               ],
             ),
           );

--- a/lib/src/widgets/list/wrap_generate.dart
+++ b/lib/src/widgets/list/wrap_generate.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forms360_uikit/forms360_uikit.dart';
 
-class WrapGenerator<T> extends StatefulWidget {
+class WrapGenerator<T> extends StatelessWidget {
   final List<T> list;
   final String? label;
   final IconData? icon;
@@ -24,27 +24,8 @@ class WrapGenerator<T> extends StatefulWidget {
   });
 
   @override
-  State<WrapGenerator<T>> createState() => _WrapGeneratorState<T>();
-}
-
-class _WrapGeneratorState<T> extends State<WrapGenerator<T>> {
-  late final ScrollController _scrollController;
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return widget.list.isNotEmpty
+    return list.isNotEmpty
         ? ScrollbarTheme(
             data: ScrollbarThemeData(
               thumbColor: WidgetStateProperty.all(
@@ -52,7 +33,6 @@ class _WrapGeneratorState<T> extends State<WrapGenerator<T>> {
               ),
             ),
             child: Scrollbar(
-              controller: _scrollController,
               thickness: 6.0,
               interactive: true,
               thumbVisibility: true,
@@ -60,38 +40,37 @@ class _WrapGeneratorState<T> extends State<WrapGenerator<T>> {
               radius: Radius.circular(10),
               scrollbarOrientation: ScrollbarOrientation.right,
               child: SingleChildScrollView(
-                controller: _scrollController,
                 child: Wrap(
                   alignment: WrapAlignment.start,
-                  spacing: widget.spacing ?? 10,
-                  runSpacing: widget.runSpacing ?? 10,
+                  spacing: spacing ?? 10,
+                  runSpacing: runSpacing ?? 10,
                   children: List.generate(
-                    widget.list.length,
-                    (index) => widget.itemBuilder(widget.list[index], index),
+                    list.length,
+                    (index) => itemBuilder(list[index], index),
                   ),
                 ),
               ),
             ),
           )
         : Container(
-            margin: EdgeInsets.only(top: widget.topMargin!),
+            margin: EdgeInsets.only(top: topMargin!),
             width: double.infinity,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  widget.icon ?? Icons.inbox,
+                  icon ?? Icons.inbox,
                   size: 60,
                   color: context.primaryColor,
                 ),
                 SizedBox(height: 10),
                 Text(
-                  widget.label ?? "No matching records found",
+                  label ?? "No matching records found",
                   style: FormsKit.theme.text.primary.copyWith(
                     color: context.primaryColor,
                   ),
-                ),
+                )
               ],
             ),
           );


### PR DESCRIPTION
Reverts FlutterLabTeam/forms360_uikit#34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts list generator widgets to Stateless, removes `getItemWidget` from `DynamicDropdownWritableInput` (using `getStringValue` for rendering) and updates callers, plus minor OTP input styling/formatting tweaks.
> 
> - **Widgets (Lists)**:
>   - Refactor `GridViewGenerator`, `ListGenerator`, and `WrapGenerator` from `StatefulWidget` to `StatelessWidget`, removing internal `ScrollController` usage and simplifying scrollbars.
> - **Inputs (Dynamic Dropdown)**:
>   - Remove `getItemWidget` prop from `DynamicDropdownWritableInput` and its usage; `itemBuilder` now renders `Text` from `getStringValue`.
>   - Update `Inputs.dynamicDropDown` to match the new API.
> - **Inputs (OTP)**:
>   - Tweak `CustomInputOtpMobile` text style (remove forced font size) and formatting; minor `buildCounter` formatting in OTP widgets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b95200ebd6d68c05cdd2acf813c3c7277302285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->